### PR TITLE
Handle exception if provider is not available, sort data items

### DIFF
--- a/src/main/java/bisq/price/spot/ExchangeRateService.java
+++ b/src/main/java/bisq/price/spot/ExchangeRateService.java
@@ -21,6 +21,8 @@ import bisq.price.spot.providers.BitcoinAverage;
 
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +65,11 @@ class ExchangeRateService {
 
         return new LinkedHashMap<String, Object>() {{
             putAll(metadata);
-            put("data", allExchangeRates.values());
+            // Use a sorted list by currency code to make comparision of json data between different
+            // price nodes easier
+            List<ExchangeRate> values = new ArrayList<>(allExchangeRates.values());
+            values.sort(Comparator.comparing(ExchangeRate::getCurrency));
+            put("data", values);
         }};
     }
 


### PR DESCRIPTION
- In case a provider is not available we still want to deliver the data of the other providers, so we catch a possible exception and leave timestamp at 0. The Bisq app will check if the timestamp is in a tolerance window and if it is too old it will show that the price is not available.

- Use a sorted list by currency code to make comparision of json data between different price nodes easier